### PR TITLE
Bool type was added.

### DIFF
--- a/perl6-font-lock.el
+++ b/perl6-font-lock.el
@@ -225,7 +225,7 @@
                     "Version" "Num" "Complex" "Bit" "True" "False" "Order" "Same"
                     "Less" "More" "Increasing" "Decreasing" "Ordered" "Callable"
                     "AnyChar" "Positional" "Associative" "Ordering" "KeyExtractor"
-                    "Comparator" "OrderingPair" "IO" "KitchenSink" "Role" "Int"
+                    "Comparator" "OrderingPair" "IO" "KitchenSink" "Role" "Int" "Bool"
                     "Rat" "Buf" "UInt" "Abstraction" "Numeric" "Real" "Nil" "Mu")))
         (version . ,(rx "v" (1+ digit) (0+ "." (or "*" (1+ digit))) (opt "+")))
         (number


### PR DESCRIPTION
Since http://doc.perl6.org/type.html has 'Bool' type included, we should highlight it properly.
