### PR TITLE
Fix { } after { }. Fixes #7

### DIFF
--- a/perl6-detect.el
+++ b/perl6-detect.el
@@ -11,6 +11,8 @@
 
 ;;;###autoload
 (add-to-list 'interpreter-mode-alist '("perl6" . perl6-mode))
+(add-to-list 'interpreter-mode-alist '("spit" . spit-mode))
+(add-to-list 'auto-mode-alist '("\\.spt\\'" . spit-mode))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.p[lm]?6\\'" . perl6-mode))

--- a/perl6-font-lock.el
+++ b/perl6-font-lock.el
@@ -281,6 +281,8 @@
     (modify-syntax-entry ?= "." table)
     (modify-syntax-entry ?> "." table)
     (modify-syntax-entry ?| "." table)
+    (modify-syntax-entry ?# "<" table)
+    (modify-syntax-entry ?\n ">" table)
     table)
   "The top level syntax table for Perl 6.")
 

--- a/perl6-indent.el
+++ b/perl6-indent.el
@@ -57,7 +57,7 @@
     (`(:list-intro . ,(or `";" `"")) t) ;"" stands for BOB (bug#15467).
     (`(:before . "{")
      (when (smie-rule-hanging-p)
-       (smie-backward-sexp ";")
+       (smie-forward-sexp)
        (smie-indent-virtual)))
     (`(:before . ,(or "{" "("))
      (if (smie-rule-hanging-p) (smie-rule-parent 0)))))

--- a/perl6-mode.el
+++ b/perl6-mode.el
@@ -60,6 +60,12 @@
               :forward-token #'perl6-smie--forward-token
               :backward-token #'perl6-smie--backward-token))
 
+;;;###autoload
+(define-derived-mode spit-mode perl6-mode "Spit"
+  "Major mode for editing Spit code."
+  )
+
+(provide 'spit-mode)
 (provide 'perl6-mode)
 
 ;; Local Variables:


### PR DESCRIPTION
This fixes:
https://github.com/hinrik/perl6-mode/issues/7

I don't really understand how smie works but I've been using this patch for a few weeks now and haven't noticed any regressions.