### PR TITLE
Add .raku file extension to perl6-detect.el

### DIFF
--- a/perl6-detect.el
+++ b/perl6-detect.el
@@ -16,6 +16,9 @@
 (add-to-list 'auto-mode-alist '("\\.p[lm]?6\\'" . perl6-mode))
 
 ;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.raku\\'" . perl6-mode))
+
+;;;###autoload
 (defconst perl6-magic-pattern
   (rx line-start
       (0+ space)


### PR DESCRIPTION
Add support for the new `.raku` file extension
https://github.com/perl6/problem-solving/blob/master/solutions/language/Path-to-Raku.md#in-the-period-immediately-after-the-rename-is-agreed